### PR TITLE
Optimize hardhat oz contracts helpers artifacts

### DIFF
--- a/hardhat/hardhat-oz-contracts-helpers/hook-handlers/hre.ts
+++ b/hardhat/hardhat-oz-contracts-helpers/hook-handlers/hre.ts
@@ -3,31 +3,26 @@ import type { HardhatRuntimeEnvironmentHooks, HookContext } from 'hardhat/types/
 import type { HardhatRuntimeEnvironment } from 'hardhat/types/hre';
 import type { ArtifactManager } from 'hardhat/types/artifacts';
 
-const suffixes = ['UpgradeableWithInit', 'Upgradeable', ''];
-
-function isExpectedError(e: unknown, suffix: string): boolean {
-  return HardhatError.isHardhatError(e) && e.number === 1000 && suffix !== '';
-}
+const suffixes = ['UpgradeableWithInit', 'Upgradeable'];
 
 const overrideReadArtifact =
-  (runSuper: ArtifactManager['readArtifact']) =>
+  (artifactExists: ArtifactManager['artifactExists'], runSuper: ArtifactManager['readArtifact']) =>
   async <ContractNameT extends string>(contractNameOrFullyQualifiedName: ContractNameT) => {
     for (const suffix of suffixes) {
-      try {
+      const artifactWithSuffix = contractNameOrFullyQualifiedName + suffix;
+      if (await artifactExists(artifactWithSuffix)) {
         return await runSuper((contractNameOrFullyQualifiedName + suffix) as ContractNameT);
-      } catch (e) {
-        if (isExpectedError(e, suffix)) {
-          continue;
-        } else {
-          throw e;
-        }
       }
     }
-    throw new Error('Unreachable');
+
+    return await runSuper(contractNameOrFullyQualifiedName as ContractNameT);
   };
 
 export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
   created: async (context: HookContext, hre: HardhatRuntimeEnvironment): Promise<void> => {
-    hre.artifacts.readArtifact = overrideReadArtifact(hre.artifacts.readArtifact.bind(hre.artifacts));
+    hre.artifacts.readArtifact = overrideReadArtifact(
+      hre.artifacts.artifactExists.bind(hre.artifacts),
+      hre.artifacts.readArtifact.bind(hre.artifacts),
+    );
   },
 });

--- a/hardhat/hardhat-oz-contracts-helpers/hook-handlers/hre.ts
+++ b/hardhat/hardhat-oz-contracts-helpers/hook-handlers/hre.ts
@@ -11,7 +11,7 @@ const overrideReadArtifact =
     for (const suffix of suffixes) {
       const artifactWithSuffix = contractNameOrFullyQualifiedName + suffix;
       if (await artifactExists(artifactWithSuffix)) {
-        return await runSuper((contractNameOrFullyQualifiedName + suffix) as ContractNameT);
+        return await runSuper(artifactWithSuffix as ContractNameT);
       }
     }
 

--- a/hardhat/hardhat-oz-contracts-helpers/hook-handlers/hre.ts
+++ b/hardhat/hardhat-oz-contracts-helpers/hook-handlers/hre.ts
@@ -1,4 +1,3 @@
-import { HardhatError } from '@nomicfoundation/hardhat-errors';
 import type { HardhatRuntimeEnvironmentHooks, HookContext } from 'hardhat/types/hooks';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types/hre';
 import type { ArtifactManager } from 'hardhat/types/artifacts';
@@ -7,16 +6,15 @@ const suffixes = ['UpgradeableWithInit', 'Upgradeable'];
 
 const overrideReadArtifact =
   (artifactExists: ArtifactManager['artifactExists'], runSuper: ArtifactManager['readArtifact']) =>
-  async <ContractNameT extends string>(contractNameOrFullyQualifiedName: ContractNameT) => {
-    for (const suffix of suffixes) {
-      const artifactWithSuffix = contractNameOrFullyQualifiedName + suffix;
-      if (await artifactExists(artifactWithSuffix)) {
-        return await runSuper(artifactWithSuffix as ContractNameT);
-      }
-    }
-
-    return await runSuper(contractNameOrFullyQualifiedName as ContractNameT);
-  };
+  <ContractNameT extends string>(contractNameOrFullyQualifiedName: ContractNameT) =>
+    suffixes
+      .map(suffix => contractNameOrFullyQualifiedName + suffix)
+      .reduce<Promise<string | false | undefined>>(
+        (acc, artifactWithSuffix) =>
+          acc.then(result => result || artifactExists(artifactWithSuffix).then(exists => exists && artifactWithSuffix)),
+        Promise.resolve(undefined),
+      )
+      .then(artifactWithSuffix => runSuper((artifactWithSuffix || contractNameOrFullyQualifiedName) as ContractNameT));
 
 export default async (): Promise<Partial<HardhatRuntimeEnvironmentHooks>> => ({
   created: async (context: HookContext, hre: HardhatRuntimeEnvironment): Promise<void> => {


### PR DESCRIPTION
This method used to call readArtifact with a try/catch to check if an artifact existed. This is slower than calling `hre.artifacts.artifactExists` as the errors thrown by `readArtifact` compute the list of similar artifact names.

This PR changes the overload to check if an artifact exists using `artifactExists` first, and only calling `readArtifact` if that's
positive.
