### PR TITLE
fix failing coverage ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "glob": "^13.0.0",
         "globals": "^17.0.0",
         "graphlib": "^2.1.8",
-        "hardhat": "^3.4.4",
+        "hardhat": "^3.5.0",
         "hardhat-ignore-warnings": "^0.3.0",
         "hardhat-predeploy": "^1.0.1",
         "husky": "^9.1.7",
@@ -1602,28 +1602,28 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.12.0-next.31",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0-next.31.tgz",
-      "integrity": "sha512-4I2R1qFsCLiKelOhqSahkz0+MnazdV+33iN0NEeen6rHaQoTYSLCpsMyb9Uj4MfunYa5QLSz2WrtO2f9E7Fegg==",
+      "version": "0.12.0-next.33",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0-next.33.tgz",
+      "integrity": "sha512-+jwZcGgUKVUykqP+hbVEXClpqZbIdo/MztP/6Xp8DDmB8c+WxJvwCDmPrnfkV+s3NNj2lSDCyOZoPw9/UNcmXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.31",
-        "@nomicfoundation/edr-darwin-x64": "0.12.0-next.31",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.31",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.31",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.31",
-        "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.31",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.31"
+        "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.33",
+        "@nomicfoundation/edr-darwin-x64": "0.12.0-next.33",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.33",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.33",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.33",
+        "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.33",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.33"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.12.0-next.31",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0-next.31.tgz",
-      "integrity": "sha512-z2gEimnvx6SinJsHsat89USFt+0sclSY4PkeI/FBFlAshiEHYKjFpN5svdC3ghOrgIFctGt7lSzfrbiP+KhVZg==",
+      "version": "0.12.0-next.33",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0-next.33.tgz",
+      "integrity": "sha512-CEaDltNmTRLyJPMwSVHNtYuXthJ3vm44SkRAQLiDYuhLbbzxAWmkCdnvKyo5QPmaRKxBGFwtahCJz2biBM43Ig==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1631,9 +1631,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.12.0-next.31",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0-next.31.tgz",
-      "integrity": "sha512-WbiIuARMO59XY8ZFs8ZFHildyMf5tnWIOt9S1wttcoYkiXwYwI2tC9JIrZ3rziv4DttWIV5aPxp23G7W0A1t4g==",
+      "version": "0.12.0-next.33",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0-next.33.tgz",
+      "integrity": "sha512-3V5XgzKLXFO+Cw0sWoO3ug2hHYL3VThskA1Iu98EPO44P4w0S6tW3bdsIH2OJPD+zi5RIHjg8H6HDZ+xeipXAA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1641,9 +1641,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.12.0-next.31",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0-next.31.tgz",
-      "integrity": "sha512-Q9p/wk6DEjGeLqp/RXiCQ8vR5irZpF6emXKElkt6jxjrOYd6VnFPc6I8v8M1Lc620aT6pn2mRwKDuKcktuqcFA==",
+      "version": "0.12.0-next.33",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0-next.33.tgz",
+      "integrity": "sha512-5+1wkqlUEem9yhKX2AwSINlaiNk6NYfm4WbvaeEAmDZivLEDhW56BNe5+fuue1B4Fa50OONaimw9wEe3d1xYNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1651,9 +1651,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.12.0-next.31",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0-next.31.tgz",
-      "integrity": "sha512-/5TYcR+NpkfxYKQbhLFN5Vj36GUqP6NqCkYqfdKuv2+0r3y4hadeU3p3WhCKr5YGrnSJwrxBnGBZwyfeHJHP+g==",
+      "version": "0.12.0-next.33",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0-next.33.tgz",
+      "integrity": "sha512-/Zr+9HxJfOSjtSTr3PkErSrGkP40j5op2koY1vVwsC1CqRiNnxKfXpwa6WH8zEUzIkEAGLq5ZwjD251irrf1uA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1661,9 +1661,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.12.0-next.31",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0-next.31.tgz",
-      "integrity": "sha512-T1EqWrja6oWglHSi0TtmITaic4DaAT+7u3yoOrjMh2oDQU+tM6tHNENWyZ244Neru23bg0i9ZnO0o8nI9uL99g==",
+      "version": "0.12.0-next.33",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0-next.33.tgz",
+      "integrity": "sha512-KrK/eUlVJo6FdHOBx9kXnzq8g+j8A2218ZVoVI/TJYgZFRXkhUI0tBeDmmdmfcRtk8J4Hw5QGRJVIXA2TAWUZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1671,9 +1671,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.12.0-next.31",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0-next.31.tgz",
-      "integrity": "sha512-gvQV4DVmnYobOuqsxuPjPuzdmpxR8yEbV75JOw5luVU6te6SBrPcmk8NNn12ZkAlTbyuDc81c7aRd4A1RfEmuw==",
+      "version": "0.12.0-next.33",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0-next.33.tgz",
+      "integrity": "sha512-o6Kmj4YKdRNZ6U4wn2hd0wyh3r2Pu0/RjBBiqs+zeeRopI/san7H4n6kIxe+8PbqlAcC48MI+oWLSNwnkqONwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.12.0-next.31",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0-next.31.tgz",
-      "integrity": "sha512-xUDeakZGAZF010k0mhAm387gny0gdKq2pHv+7MxqVvuQumW0PNKQfBNfl7+bNgt9Bc4o1/FBP89hUR5tHXU0Cg==",
+      "version": "0.12.0-next.33",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0-next.33.tgz",
+      "integrity": "sha512-PPiOTOIShzhK7+i+QMDz6/0m2JcEHBMqCthLj8dru2RFhXT1Jory35u12awaVS2fU91flBg7zz7Qju4v8hrnLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1691,13 +1691,13 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-errors": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.12.tgz",
-      "integrity": "sha512-2viEq1D19FHWKpfB2vVeL0R6d+iZR2E5h0EhKQQMc1ukDUV2fel/7fRjlWuCOx2CFC+5mHL2saRcN8KlYsX8hg==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.13.tgz",
+      "integrity": "sha512-h0nWNzKbmP6XhINMgSUfGixevzksT8BQPK08KNnsr/8kQORAeYzsv6bf0CLUD8mZfmBEP45m4QMlNP6xcoc0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-utils": "^4.1.0"
+        "@nomicfoundation/hardhat-utils": "^4.1.2"
       }
     },
     "node_modules/@nomicfoundation/hardhat-ethers": {
@@ -1905,9 +1905,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-4.1.0.tgz",
-      "integrity": "sha512-qze9X5P8LIB36rjS3cFhD7asG82pjZDmJAYfCQBSDhMYJM1HDZrYKgKfJLEE36TmrhjgQ/hlNO0DikDq0e2VYg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-4.1.2.tgz",
+      "integrity": "sha512-jUQfbyIoTLHmSua+BMhIqUIk7uDwL2bhTtJgfwRoVooM3TTvm5rIdRK+eNkvZcZR/wAL/SBQOq/r9yOekj4Unw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2009,21 +2009,21 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-vendored": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-vendored/-/hardhat-vendored-3.0.3.tgz",
-      "integrity": "sha512-VzxwR1Yz8zAztiSIkjFai/XyqfuMMvX95ppXxWlJ1ci0TiHu6sut1oOAD+VJVCq+LHNpr2fWMUcugZq9uKbicg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-vendored/-/hardhat-vendored-3.0.4.tgz",
+      "integrity": "sha512-RO8Otj1FvRvxJmXzkxh1vTwK/+cqSVPYLqY6RrWkmzHEEcxnAwAFsBYdW7xyTEyW/pVbSSNd2gs3aoGdGZaoNA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@nomicfoundation/hardhat-zod-utils": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-zod-utils/-/hardhat-zod-utils-3.0.4.tgz",
-      "integrity": "sha512-yCiycXDEEjbNgNVQaUoGYOee6+ljYUnIOWMtYc/dYDuwlHutWr9xg/KgkgMkiZZ1R2WrZAEqsSaeZTnH7Oyz9Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-zod-utils/-/hardhat-zod-utils-3.0.5.tgz",
+      "integrity": "sha512-A1G9Jcizf/vYcGMtqkf+st94zBPTDB+bXXlojOMu77gmBZYbywY0k7hdRM2B4uJY+8nM0oe0sNVGVkARITXdcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-errors": "^3.0.11",
-        "@nomicfoundation/hardhat-utils": "^4.0.3"
+        "@nomicfoundation/hardhat-errors": "^3.0.13",
+        "@nomicfoundation/hardhat-utils": "^4.1.2"
       },
       "peerDependencies": {
         "zod": "^3.23.8"
@@ -4458,17 +4458,17 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.4.4.tgz",
-      "integrity": "sha512-m7EbNA++jZu3h8KuLxHY/vCMTbWfnlXPHO+iKO3v8XoHOBiplVIy5V4MsblcursS694r1fINaFC26a6xd7kY8Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.5.0.tgz",
+      "integrity": "sha512-JT5YMXluyCD6RePp1ySezgZD9zZelS0v/wtarkQHb44pGqWqvVz1E68aEKSsbdMDRjHSHvW7/ILNJ3N1wt/MqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr": "0.12.0-next.31",
-        "@nomicfoundation/hardhat-errors": "^3.0.12",
-        "@nomicfoundation/hardhat-utils": "^4.1.0",
-        "@nomicfoundation/hardhat-vendored": "^3.0.3",
-        "@nomicfoundation/hardhat-zod-utils": "^3.0.4",
+        "@nomicfoundation/edr": "0.12.0-next.33",
+        "@nomicfoundation/hardhat-errors": "^3.0.13",
+        "@nomicfoundation/hardhat-utils": "^4.1.2",
+        "@nomicfoundation/hardhat-vendored": "^3.0.4",
+        "@nomicfoundation/hardhat-zod-utils": "^3.0.5",
         "@nomicfoundation/solidity-analyzer": "^0.1.1",
         "@sentry/core": "^9.4.0",
         "adm-zip": "^0.4.16",
@@ -7185,9 +7185,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7205,9 +7202,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "glob": "^13.0.0",
     "globals": "^17.0.0",
     "graphlib": "^2.1.8",
-    "hardhat": "^3.4.4",
+    "hardhat": "^3.5.0",
     "hardhat-ignore-warnings": "^0.3.0",
     "hardhat-predeploy": "^1.0.1",
     "husky": "^9.1.7",

--- a/test/account/Account.behavior.js
+++ b/test/account/Account.behavior.js
@@ -60,7 +60,7 @@ export function shouldBehaveLikeAccountCore() {
 
         // Forcing the gas limit here to work around a hardhat 3 issue with gas estimation
         await expect(
-          this.mockFromEntrypoint.validateUserOp(operation.packed, operation.hash(), value, { gasLimit: 200_000n }),
+          this.mockFromEntrypoint.validateUserOp(operation.packed, operation.hash(), value, { gasLimit: 2_000_000n }),
         ).to.changeEtherBalances(this.ethers, [this.mock, this.ethers.predeploy.entrypoint.v09], [-value, value]);
       });
     });

--- a/test/governance/TimelockController.test.js
+++ b/test/governance/TimelockController.test.js
@@ -1150,7 +1150,7 @@ describe('TimelockController', function () {
         this.mock
           .connect(this.executor)
           .execute(operation.target, operation.value, operation.data, operation.predecessor, operation.salt, {
-            gasLimit: '500000',
+            gasLimit: '500_000n',
           }),
       ).to.be.revertedWithCustomError(this.mock, 'FailedCall');
     });

--- a/test/governance/TimelockController.test.js
+++ b/test/governance/TimelockController.test.js
@@ -1143,11 +1143,14 @@ describe('TimelockController', function () {
 
       await this.mock.getTimestamp(operation.id).then(time.increaseTo.timestamp);
 
+      // Outer gas budget must leave enough for the FailedCall revert site after the inner OOGs.
+      // Instrumented bytecode under `--coverage` adds per-statement probes, so 100k is too tight;
+      // 500k gives headroom while still well below the EIP-7825 (Osaka) per-tx cap of 2^24.
       await expect(
         this.mock
           .connect(this.executor)
           .execute(operation.target, operation.value, operation.data, operation.predecessor, operation.salt, {
-            gasLimit: '100000',
+            gasLimit: '500000',
           }),
       ).to.be.revertedWithCustomError(this.mock, 'FailedCall');
     });


### PR DESCRIPTION
Two small changes to get the coverage CI job running to completion:

1. Increase two hard-coded gas values that failed under `--coverage` because of the additional gas consumption of instrumentation
2. Update to the latest version of Hardhat, which disables the per transaction gas cap and block gas limit when running under `--coverage`
